### PR TITLE
Fix showing cancel etc notification when event messages off

### DIFF
--- a/js/event_form_new_participant_mods.js
+++ b/js/event_form_new_participant_mods.js
@@ -80,7 +80,7 @@ cj(document).ready(function () {
     } else {
       // show the fieldset
       // console.log("show stuff");
-      cj("fieldset#send_confirmation_receipt,fieldset#email-receipt,div#notify")
+      cj("fieldset#send_confirmation_receipt,fieldset#email-receipt")
         .show()
         .change();
     }


### PR DESCRIPTION
On Edit Event Registration and similar forms, the notify option underneath the status should only be shown when changing to certain statuses (cancelled, etc). However, with the extension installed but not enabled for a particular event, this notify option was always shown underneath status. With this change, the notification option is never shown if the extension is enabled for an event and it is shown or not shown as normal if the extension is not enabled.