### PR TITLE
Symfony 6 and Drupal 10 compatibility

### DIFF
--- a/Civi/EventMessages/MessageTokenList.php
+++ b/Civi/EventMessages/MessageTokenList.php
@@ -15,7 +15,7 @@
 
 
 namespace Civi\EventMessages;
-use Symfony\Component\EventDispatcher\Event;
+use \Symfony\Contracts\EventDispatcher\Event;
 use CRM_Eventmessages_ExtensionUtil as E;
 
 /**

--- a/Civi/EventMessages/MessageTokenList.php
+++ b/Civi/EventMessages/MessageTokenList.php
@@ -15,7 +15,7 @@
 
 
 namespace Civi\EventMessages;
-use \Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use CRM_Eventmessages_ExtensionUtil as E;
 
 /**

--- a/Civi/EventMessages/MessageTokens.php
+++ b/Civi/EventMessages/MessageTokens.php
@@ -15,7 +15,7 @@
 
 
 namespace Civi\EventMessages;
-use \Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class MessageTokens

--- a/Civi/EventMessages/MessageTokens.php
+++ b/Civi/EventMessages/MessageTokens.php
@@ -15,7 +15,7 @@
 
 
 namespace Civi\EventMessages;
-use Symfony\Component\EventDispatcher\Event;
+use \Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class MessageTokens


### PR DESCRIPTION
Following advise from [a CiviCRM issue](https://lab.civicrm.org/dev/core/-/issues/2316#note_84886), this replaces usages of `Symfony\Component\EventDispatcher\Event` with `\Symfony\Contracts\EventDispatcher\Event`, which is where the class moved to in Symfony 6 (and had an alias to in Symfony 5, if I recall correctly).

This removes compatibility with Symfony 4, which is in LTS support and will be EOL in Nov 2023.

The issue comment above suggests using `\Civi\Core\Event\GenericHookEvent` for keeping compatiblity, but this class has a somewhat different purpose.

As Drupal 10 requires Symfony 6, this makes this extension compatible with Drupal 10 as well.