### PR TITLE
Logic: Handle rules on post commit

### DIFF
--- a/eventmessages.php
+++ b/eventmessages.php
@@ -76,22 +76,32 @@ function eventmessages_civicrm_tabset($tabsetName, &$tabs, $context)
 }
 
 /**
- * Monitor Participant objects
+ * Monitor Participant edits
  */
-function eventmessages_civicrm_pre($op, $objectName, $id, &$params)
+function eventmessages_civicrm_pre(string $op, string $objectName, $id, array &$params): void
 {
-    if (($op == 'edit' || $op == 'create') && $objectName == 'Participant') {
-        CRM_Eventmessages_Logic::recordPre($id, $params);
+    if ($op === 'edit' && $objectName === 'Participant') {
+        CRM_Eventmessages_Logic::recordPreEdit((int) $id, $params);
     }
 }
 
 /**
- * Monitor Participant objects
+ * Monitor Participant creations
  */
-function eventmessages_civicrm_post($op, $objectName, $objectId, &$objectRef)
+function eventmessages_civicrm_post(string $op, string $objectName, int $objectId, &$objectRef): void
 {
-    if (($op == 'edit' || $op == 'create') && $objectName == 'Participant') {
-        CRM_Eventmessages_Logic::recordPost($objectId, $objectRef);
+    if ($op === 'create' && $objectName === 'Participant') {
+        CRM_Eventmessages_Logic::recordPostCreate($objectId);
+    }
+}
+
+/**
+ * Monitor Participant post commit
+ */
+function eventmessages_civicrm_postCommit(string $op, string $objectName, int $objectId, &$objectRef): void
+{
+    if (($op === 'edit' || $op === 'create') && $objectName === 'Participant') {
+        CRM_Eventmessages_Logic::recordPostCommit($objectId, $objectRef);
     }
 }
 


### PR DESCRIPTION
With this change rules are handled after database commit. This fixes those issues:
* Rule matching (potentially resulting in sending of a message) for every status change/forced execution during a single transaction.
* Message is sent (e.g. confirmation), but change is not persisted because of a rollback.
* Custom fields of Participant are not up to date in `post hook`. (Civi Core [PR](https://github.com/civicrm/civicrm-core/pull/28379), required for #45).