### PR TITLE
Replace APIv3 call with APIv4 call in `CRM_Eventmessages_GenerateLetterJob` and `CRM_Eventmessages_SendMailJob`

### DIFF
--- a/CRM/Eventmessages/Form/Task/ParticipantEmail.php
+++ b/CRM/Eventmessages/Form/Task/ParticipantEmail.php
@@ -127,7 +127,7 @@ class CRM_Eventmessages_Form_Task_ParticipantEmail extends CRM_Event_Form_Task
                         E::ts("Sending Emails %1 - %2", [
                             1 => $next_offset, // keep in mind that this is showing when the _next_ task is running
                             2 => $next_offset + self::RUNNER_BATCH_SIZE]),
-                        $values['attachments']
+                        $values['attachments'] ?? []
                     )
                 );
                 $next_offset += self::RUNNER_BATCH_SIZE;
@@ -139,7 +139,7 @@ class CRM_Eventmessages_Form_Task_ParticipantEmail extends CRM_Event_Form_Task
         $queue->createItem(
             new CRM_Eventmessages_SendMailJob(
                 $current_batch,
-                $values['template_id'],
+                (int) $values['template_id'],
                 E::ts("Finishing"),
                 $values['attachments']
             )
@@ -226,4 +226,3 @@ class CRM_Eventmessages_Form_Task_ParticipantEmail extends CRM_Event_Form_Task
               AND email.id IS NULL");
     }
 }
-

--- a/CRM/Eventmessages/Form/Task/ParticipantLetter.php
+++ b/CRM/Eventmessages/Form/Task/ParticipantLetter.php
@@ -110,7 +110,7 @@ class CRM_Eventmessages_Form_Task_ParticipantLetter extends CRM_Event_Form_Task
             new CRM_Eventmessages_GenerateLetterJob(
                 'init',
                 [],
-                $values['template_id'],
+                (int) $values['template_id'],
                 $temp_folder,
                 E::ts("Initialized")
             )
@@ -152,7 +152,7 @@ class CRM_Eventmessages_Form_Task_ParticipantLetter extends CRM_Event_Form_Task
                 new CRM_Eventmessages_GenerateLetterJob(
                     'run',
                     $current_batch,
-                    $values['template_id'],
+                    (int) $values['template_id'],
                     $temp_folder,
                     E::ts(
                         "Generated letters %1 of %2",
@@ -172,7 +172,7 @@ class CRM_Eventmessages_Form_Task_ParticipantLetter extends CRM_Event_Form_Task
             new CRM_Eventmessages_GenerateLetterJob(
                 'finish',
                 [],
-                $values['template_id'],
+                (int) $values['template_id'],
                 $temp_folder,
                 E::ts("Finished")
             )


### PR DESCRIPTION
Cause for this change is that on one system the APIv3 call `Participant.get` didn't return when `status_id` was selected. (The actual reason isn't clear though it's not related to this extension and using APIv4 instead of APIv3 makes sense anyway.)

systopia-reference: 27953