### PR TITLE
Remove Smarty modifier unsupported in Smarty 5

### DIFF
--- a/templates/CRM/Eventmessages/Form/EventMessages.tpl
+++ b/templates/CRM/Eventmessages/Form/EventMessages.tpl
@@ -68,7 +68,7 @@
         </tr>
 
         <tr class="crm-event-manage-eventmessages-form-block-language_provider_names">
-          <td class="label">{$form.language_provider_names.label} {help id="id-language-provider-names" options=$language_provider_options_help|html_entity_decode title=$form.language_provider_names.label}</td>
+          <td class="label">{$form.language_provider_names.label} {help id="id-language-provider-names" options=$language_provider_options_help title=$form.language_provider_names.label}</td>
           <td>{$form.language_provider_names.html} </td>
         </tr>
       </table>


### PR DESCRIPTION
Fixes #58.

The relevant changes are only [those](https://github.com/systopia/de.systopia.eventmessages/compare/extension-template...smarty-modifier) (rebased this PR on a branch with our extension template applied).

The help bubble doesn't open even with the modifier anyway, so removing it solves the incompatibility issue.

For actually fixing the underlying problem of escaping parameters to `{help}` I created a PR upstream: civicrm/civicrm-core#33014 (already merged), although this is not a major bug and shouldn't block a stable release of this extension.