### PR TITLE
Make Smarty tokens possible again in message template

### DIFF
--- a/CRM/Eventmessages/Util/SmartyTokenFlattener.php
+++ b/CRM/Eventmessages/Util/SmartyTokenFlattener.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+/**
+ * Prepares Smarty tokens for use in TokenProcessor. TokenProcessor requires a token entity and doesn't allow arrays
+ * as token values.
+ */
+final class CRM_Eventmessages_Util_SmartyTokenFlattener {
+
+  /**
+   * @var array<string, string>
+   */
+  private array $aliases = [];
+
+  private string $template;
+
+  /**
+   * @var array<string, array<string, mixed>>
+   */
+  private array $tokens = [];
+
+  public function __construct(string $template) {
+    $this->template = $template;
+  }
+
+  /**
+   * @param array<string, mixed> $tokens
+   */
+  public function flattenTokens(array $tokens, string $tokenEntity, string $prefix = ''): void {
+    foreach ($tokens as $tokenName => $tokenValue) {
+      if (is_array($tokenValue)) {
+        // Arrays are not allowed as token value in TokenProcessor.
+        $subPrefix = "$prefix${tokenName}__";
+        $this->template = str_replace('{$' . "$tokenName.", '{$' . $subPrefix, $this->template);
+        // @phpstan-ignore argument.type
+        $this->flattenTokens($tokenValue, $tokenEntity, $subPrefix);
+      }
+      else {
+        $fullTokenName = $prefix . $tokenName;
+        $this->tokens[$tokenEntity][$fullTokenName] = $tokenValue;
+        $this->aliases[$fullTokenName] = "$tokenEntity.$fullTokenName";
+      }
+    }
+  }
+
+  /**
+   * @return array<string, string>
+   */
+  public function getAliases(): array {
+    return $this->aliases;
+  }
+
+  public function getTemplate(): string {
+    return $this->template;
+  }
+
+  /**
+   * @return array<string, array<string, mixed>>
+   */
+  public function getTokens(): array {
+    return $this->tokens;
+  }
+
+}

--- a/Civi/EventMessages/MessageTokens.php
+++ b/Civi/EventMessages/MessageTokens.php
@@ -56,6 +56,20 @@ class MessageTokens extends Event {
   }
 
   /**
+   * @return array<string, mixed>
+   */
+  public function getSmartyTokens(): array {
+    $this->initTemplateTokens();
+
+    $tokens = [];
+    foreach (array_keys($this->template_tokens) as $name) {
+      $tokens[$name] = $this->tokens[$name] ?? NULL;
+    }
+
+    return $tokens;
+  }
+
+  /**
    * Specify the template's data, so the contained
    *   tokens can be extracted
    *
@@ -94,7 +108,7 @@ class MessageTokens extends Event {
   }
 
   /**
-   * Check if the given token is required
+   * Check if the given Smarty token is required
    *
    * @param string $name
    *   token name
@@ -108,16 +122,7 @@ class MessageTokens extends Event {
       return TRUE;
     }
 
-    // extract template tokens on the fly
-    if (!isset($this->template_tokens)) {
-      // we have template_data but have not derived the tokens - let's do that
-      $this->template_tokens = [];
-      if (preg_match_all('/[$](\w+)/', $this->template_data, $matches)) {
-        foreach ($matches[1] as $token) {
-          $this->template_tokens[$token] = TRUE;
-        }
-      }
-    }
+    $this->initTemplateTokens();
 
     // finally, return if the token is used
     return isset($this->template_tokens[$name]);
@@ -162,6 +167,19 @@ class MessageTokens extends Event {
       // todo: more stuff?
     }
     return $tokens;
+  }
+
+  private function initTemplateTokens(): void {
+    // extract template tokens on the fly
+    if (!isset($this->template_tokens)) {
+      // we have template_data but have not derived the tokens - let's do that
+      $this->template_tokens = [];
+      if (preg_match_all('/[$](\w+)/', $this->template_data, $matches)) {
+        foreach ($matches[1] as $token) {
+          $this->template_tokens[$token] = TRUE;
+        }
+      }
+    }
   }
 
 }

--- a/ci/composer.json
+++ b/ci/composer.json
@@ -10,6 +10,7 @@
         "sort-packages": true
     },
     "require": {
-        "civicrm/civicrm-core": ">=5.68"
+        "civicrm/civicrm-core": ">=5.68",
+        "civicrm/civicrm-packages": ">=5.68"
     }
 }

--- a/ci/composer.json
+++ b/ci/composer.json
@@ -12,5 +12,8 @@
     "require": {
         "civicrm/civicrm-core": ">=5.68",
         "civicrm/civicrm-packages": ">=5.68"
+    },
+    "conflict": {
+      "pear/pear-core-minimal": "<1.10.10"
     }
 }

--- a/ci/composer.json
+++ b/ci/composer.json
@@ -14,6 +14,7 @@
         "civicrm/civicrm-packages": ">=5.68"
     },
     "conflict": {
+      "pear/console_getopt": "<1.4.3",
       "pear/pear-core-minimal": "<1.10.10"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,6 +23,7 @@
         <!-- Conflicts with PHPStan type hints -->
         <exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"/>
         <exclude name="Drupal.Commenting.FunctionComment.ParamTypeSpaces"/>
+        <exclude name="Drupal.Commenting.FunctionComment.ReturnTypeSpaces"/>
 
         <!-- Don't enforce phpdoc type hint because it (might) only duplicate a PHP type hint -->
         <exclude name="Drupal.Commenting.VariableComment.MissingVar"/>

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -3,7 +3,11 @@ includes:
 
 parameters:
 	scanDirectories:
-		- ci/vendor/civicrm/civicrm-core/CRM/
+		- ci/vendor/civicrm/civicrm-core/api
+		- ci/vendor/civicrm/civicrm-core/CRM
+		- ci/vendor/civicrm/civicrm-core/ext/civi_event/Civi
+	scanFiles:
+		- ci/vendor/civicrm/civicrm-packages/DB/DataObject.php
 	bootstrapFiles:
 		- ci/vendor/autoload.php
 	# Because we test with different versions in CI we have unmatched errors

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -6,6 +6,10 @@ includes:
 
 parameters:
 	scanDirectories:
-		- {VENDOR_DIR}/civicrm/civicrm-core/CRM/
+		- {VENDOR_DIR}/civicrm/civicrm-core/api
+		- {VENDOR_DIR}/civicrm/civicrm-core/CRM
+		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_event/Civi
+	scanFiles:
+		- {VENDOR_DIR}/civicrm/civicrm-packages/DB/DataObject.php
 	bootstrapFiles:
 		- {VENDOR_DIR}/autoload.php


### PR DESCRIPTION
Smarty tokens are handled in [TokenCompatSubscriber](https://github.com/civicrm/civicrm-core/blob/fe4726d62bbac159a82c42feffdfac2213707a47/Civi/Token/TokenCompatSubscriber.php#L147). Therefore, the `TokenProcessor` has to set up correctly for Smarty tokens to get resolved. Otherwise they will be replaced by a an empty string.

There are some code style changes and changes to reduce phpstan errors.

systopia-reference: 30227