### PR TITLE
#71 Cast pattern to string in preg_match

### DIFF
--- a/CRM/Eventmessages/SendMail.php
+++ b/CRM/Eventmessages/SendMail.php
@@ -412,7 +412,7 @@ class CRM_Eventmessages_SendMail {
       // copy all custom_xx parameters into the participant
       foreach ($submission_sources as $submission_source) {
         foreach ($submission_source as $key => $value) {
-          if (preg_match('/^custom_[0-9]+$/', $key)) {
+          if (preg_match('/^custom_[0-9]+$/', (string) $key)) {
             $participant[$key] = $value;
           }
         }


### PR DESCRIPTION
PR for Issue #71 

second argument of preg_match needs to be cast to string, in case for example integers are submitted.

*systopia-reference: 30099*