### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Eventmessages/CustomData.php
+++ b/CRM/Eventmessages/CustomData.php
@@ -735,7 +735,7 @@ class CRM_Eventmessages_CustomData {
         return $field_data['value'];
       } else {
         // unlikely, but worth a shot:
-        return CRM_Utils_Array::value("custom_{$field_id}", $params, NULL);
+        return $params["custom_{$field_id}"] ?? NULL;
       }
     }
     return NULL;
@@ -785,9 +785,9 @@ class CRM_Eventmessages_CustomData {
               'value'           => $value,
               'type'            => CRM_Utils_Array::value('data_type', $field_specs, 'String'),
               'custom_field_id' => $field_id,
-              'custom_group_id' => CRM_Utils_Array::value('custom_group_id', $field_specs, NULL),
-              'table_name'      => CRM_Utils_Array::value('table_name', $group_specs, NULL),
-              'column_name'     => CRM_Utils_Array::value('column_name', $field_specs, NULL),
+              'custom_group_id' => $field_specs['custom_group_id'] ?? NULL,
+              'table_name'      => $group_specs['table_name'] ?? NULL,
+              'column_name'     => $field_specs['column_name'] ?? NULL,
               'is_multiple'     => CRM_Utils_Array::value('is_multiple', $group_specs, 0),
       ];
     } else {

--- a/CRM/Eventmessages/Form/EventMessages.php
+++ b/CRM/Eventmessages/Form/EventMessages.php
@@ -261,13 +261,13 @@ class CRM_Eventmessages_Form_EventMessages extends CRM_Event_Form_ManageEvent {
     $rules = [];
     foreach (range(1, self::MAX_RULE_COUNT) as $i) {
       $rule = [
-        'id'        => CRM_Utils_Array::value("id_{$i}", $values, NULL),
+        'id'        => $values["id_{$i}"] ?? NULL,
         'is_active' => (int) CRM_Utils_Array::value("is_active_{$i}", $values, FALSE),
         'from'      => CRM_Utils_Array::value("from_{$i}", $values, []),
         'to'        => CRM_Utils_Array::value("to_{$i}", $values, []),
         'languages' => CRM_Utils_Array::value("languages_{$i}", $values, []),
         'roles'     => CRM_Utils_Array::value("roles_{$i}", $values, []),
-        'template'  => CRM_Utils_Array::value("template_{$i}", $values, NULL),
+        'template'  => $values["template_{$i}"] ?? NULL,
         'weight'    => (10 + count($rules) * 10),
       ];
       if (class_exists('\Civi\Mailattachment\Form\Attachments')) {


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.